### PR TITLE
Fix unsafe assignment to innerHTML

### DIFF
--- a/simplify.js
+++ b/simplify.js
@@ -64,12 +64,12 @@ function cleanPostDetails() {
     document.querySelectorAll(".top-matter").forEach((topMatter) => {
         // Don't care who submitted the post
         topMatter.querySelectorAll(".tagline").forEach((tagline) => {
-            tagline.innerHTML = tagline.innerHTML.replace("submitted", "").replace("by", "")
+            tagline.textContent = tagline.textContent.replace("submitted", "").replace("by", "").replace("*", "")
         });
 
         // Don't care about the number of comments
         topMatter.querySelectorAll(".bylink.comments.may-blank").forEach((commentsButton) => {
-            commentsButton.textContent = commentsButton.innerHTML.replace(/^[0-9]+/, "")
+            commentsButton.textContent = commentsButton.textContent.replace(/^[0-9]+/, "")
         });
     });
 }


### PR DESCRIPTION
Thanks Mozilla validation, very cool!

- The AMO validator notified that the use of innerHTML was unsafe, I'm
assuming it could have led to XSS.
- Switched just to using textContent (that's all I need) but I'm a baby
JS developer, so we'll see if this passes validation.
- I'm going to start using https://github.com/mozilla/addons-linter to
do these checks before hand.